### PR TITLE
Add Laravel 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
   ],
   "require": {
     "php": ">=7.2",
-    "illuminate/config": "^6.0|^7.0",
-    "illuminate/console": "^6.0|^7.0",
-    "illuminate/support": "^6.0|^7.0",
-    "illuminate/validation": "^6.0|^7.0"
+    "illuminate/config": "^6.0|^7.0|^8.0",
+    "illuminate/console": "^6.0|^7.0|^8.0",
+    "illuminate/support": "^6.0|^7.0|^8.0",
+    "illuminate/validation": "^6.0|^7.0|^8.0"
   },
   "require-dev": {
-    "orchestra/testbench": "^4.0|^5.0",
+    "orchestra/testbench": "^4.0|^5.0|^6.0",
     "phpunit/phpunit": "^8.4|^9.0"
   },
   "autoload": {


### PR DESCRIPTION
Good morning. In a project I tried to update to [Laravel 8], but I see that `laravel-env-validator` doesn't declare compatibility with packages compatibles with Laravel 8. I updated the `composer.json` and made some tests, and the project works great with Laravel 8.

At this PR, I updated the `composer.json` to require versions of packages that are compatible with Laravel 8. It's look good for you? I will wait your feedback, thanks.

[Laravel 8]: https://laravel.com/docs/8.x/releases